### PR TITLE
Fix reachable and IP leak test

### DIFF
--- a/UmlautAdaptarr/Program.cs
+++ b/UmlautAdaptarr/Program.cs
@@ -8,7 +8,10 @@ using UmlautAdaptarr.Utilities;
 
 internal class Program
 {
-    private static void Main(string[] args)
+    private static void Main(string[] args) {
+        MainAsync(args).Wait();
+    }
+    private static async Task MainAsync(string[] args)
     {
         Helper.ShowLogo();
         Helper.ShowInformation();
@@ -43,9 +46,9 @@ internal class Program
         builder.AddTitleLookupService();
         builder.Services.AddSingleton<SearchItemLookupService>();
         builder.Services.AddSingleton<TitleMatchingService>();
-        builder.AddSonarrSupport();
-        builder.AddLidarrSupport();
-        builder.AddReadarrSupport();
+        await builder.AddSonarrSupport();
+        await builder.AddLidarrSupport();
+        await builder.AddReadarrSupport();
         builder.Services.AddSingleton<CacheService>();
         builder.Services.AddSingleton<ProxyRequestService>();
         builder.Services.AddSingleton<ArrApplicationFactory>();

--- a/UmlautAdaptarr/Program.cs
+++ b/UmlautAdaptarr/Program.cs
@@ -11,10 +11,9 @@ internal class Program
     private static void Main(string[] args) {
         MainAsync(args).Wait();
     }
+
     private static async Task MainAsync(string[] args)
     {
-        Helper.ShowLogo();
-        Helper.ShowInformation();
         // TODO:
         // add option to sort by nzb age
         var builder = WebApplication.CreateBuilder(args);
@@ -56,6 +55,13 @@ internal class Program
         builder.Services.AddSingleton<IHostedService, HttpProxyService>();
 
         var app = builder.Build();
+
+        Helper.ShowLogo();
+
+        if (app.Configuration.GetValue<bool>("IpLeakTest:Enabled"))
+        {
+            await Helper.ShowInformation();
+        }
 
         GlobalStaticLogger.Initialize(app.Services.GetService<ILoggerFactory>()!);
         app.UseHttpsRedirection();

--- a/UmlautAdaptarr/Utilities/Helper.cs
+++ b/UmlautAdaptarr/Utilities/Helper.cs
@@ -11,10 +11,10 @@ public static class Helper
             "\r\n _   _           _             _    ___      _             _                  \r\n| | | |         | |           | |  / _ \\    | |           | |                 \r\n| | | |_ __ ___ | | __ _ _   _| |_/ /_\\ \\ __| | __ _ _ __ | |_ __ _ _ __ _ __ \r\n| | | | '_ ` _ \\| |/ _` | | | | __|  _  |/ _` |/ _` | '_ \\| __/ _` | '__| '__|\r\n| |_| | | | | | | | (_| | |_| | |_| | | | (_| | (_| | |_) | || (_| | |  | |   \r\n \\___/|_| |_| |_|_|\\__,_|\\__,_|\\__\\_| |_/\\__,_|\\__,_| .__/ \\__\\__,_|_|  |_|   \r\n                                                    | |                       \r\n                                                    |_|                       \r\n");
     }
 
-    public static void ShowInformation()
+    public static async Task ShowInformation()
     {
         Console.WriteLine("--------------------------[IP Leak Test]-----------------------------");
-        var ipInfo = GetPublicIpAddressInfoAsync().GetAwaiter().GetResult();
+        var ipInfo = await GetPublicIpAddressInfoAsync();
 
         if (ipInfo != null)
         {

--- a/UmlautAdaptarr/Utilities/ServicesExtensions.cs
+++ b/UmlautAdaptarr/Utilities/ServicesExtensions.cs
@@ -29,7 +29,7 @@ public static class ServicesExtensions
     /// <param name="builder">The <see cref="WebApplicationBuilder" /> to configure the service collection.</param>
     /// <param name="sectionName">The name of the configuration section containing service options.</param>
     /// <returns>The configured <see cref="WebApplicationBuilder" />.</returns>
-    private static WebApplicationBuilder AddServicesWithOptions<TOptions, TService, TInterface>(
+    private static async Task<WebApplicationBuilder> AddServicesWithOptions<TOptions, TService, TInterface>(
         this WebApplicationBuilder builder, string sectionName)
         where TOptions : class, new()
         where TService : class, TInterface
@@ -57,9 +57,9 @@ public static class ServicesExtensions
 
             foreach (var option in optionsArray)
             {
-              GlobalInstanceOptionsValidator validator = new GlobalInstanceOptionsValidator();
+              GlobalInstanceOptionsValidator validator = new();
 
-              var results =  validator.Validate(option as GlobalInstanceOptions);
+              var results = await validator.ValidateAsync(option as GlobalInstanceOptions);
 
                 if (!results.IsValid)
                 {
@@ -143,7 +143,7 @@ public static class ServicesExtensions
     /// </summary>
     /// <param name="builder">The <see cref="WebApplicationBuilder" /> to configure the service collection.</param>
     /// <returns>The configured <see cref="WebApplicationBuilder" />.</returns>
-    public static WebApplicationBuilder AddSonarrSupport(this WebApplicationBuilder builder)
+    public static Task<WebApplicationBuilder> AddSonarrSupport(this WebApplicationBuilder builder)
     {
         //  builder.Serviceses.AddSingleton<IOptionsMonitoSonarrInstanceOptionsns>, OptionsMonitoSonarrInstanceOptionsns>>();
         return builder.AddServicesWithOptions<SonarrInstanceOptions, SonarrClient, IArrApplication>("Sonarr");
@@ -154,7 +154,7 @@ public static class ServicesExtensions
     /// </summary>
     /// <param name="builder">The <see cref="WebApplicationBuilder" /> to configure the service collection.</param>
     /// <returns>The configured <see cref="WebApplicationBuilder" />.</returns>
-    public static WebApplicationBuilder AddLidarrSupport(this WebApplicationBuilder builder)
+    public static Task<WebApplicationBuilder> AddLidarrSupport(this WebApplicationBuilder builder)
     {
         return builder.AddServicesWithOptions<LidarrInstanceOptions, LidarrClient, IArrApplication>("Lidarr");
     }
@@ -164,7 +164,7 @@ public static class ServicesExtensions
     /// </summary>
     /// <param name="builder">The <see cref="WebApplicationBuilder" /> to configure the service collection.</param>
     /// <returns>The configured <see cref="WebApplicationBuilder" />.</returns>
-    public static WebApplicationBuilder AddReadarrSupport(this WebApplicationBuilder builder)
+    public static Task<WebApplicationBuilder> AddReadarrSupport(this WebApplicationBuilder builder)
     {
         return builder.AddServicesWithOptions<ReadarrInstanceOptions, ReadarrClient, IArrApplication>("Readarr");
     }

--- a/UmlautAdaptarr/appsettings.json
+++ b/UmlautAdaptarr/appsettings.json
@@ -64,5 +64,8 @@
     "Enabled": false,
     "Host": "your_readarr_host_url",
     "ApiKey": "your_readarr_api_key"
+  },
+  "IpLeakTest": {
+    "Enabled": false
   }
 }


### PR DESCRIPTION
Fix the instance reachable checks when Basic Authentication is enabled in the *arr instance by GETing `/api?apikey=<ApiKey>` instead of `/` without any authentication.
I'm not 100% sure that all supported *arrs return HTTP 200 when GETing `/api`, but it seems to work for Sonarr and Readarr on my end.

Also added a configuration option to disable the IP leak test. Setting `IPLEAKTEST__ENABLED=false` as docker environment variable will disable the check.

Fixes #40.