### PR TITLE
Add image source label to dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ RUN dotnet restore
 RUN dotnet publish -c Release -o out
 
 FROM mcr.microsoft.com/dotnet/aspnet:8.0
+LABEL org.opencontainers.image.source="https://github.com/PCJones/UmlautAdaptarr"
 WORKDIR /app
 COPY --from=build-env /app/out .
 ENTRYPOINT ["dotnet", "UmlautAdaptarr.dll"]

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -6,6 +6,7 @@ RUN dotnet restore
 RUN dotnet publish -c Release -o out
 
 FROM --platform=linux/arm64 mcr.microsoft.com/dotnet/aspnet:8.0
+LABEL org.opencontainers.image.source="https://github.com/PCJones/UmlautAdaptarr"
 WORKDIR /app
 COPY --from=build-env /app/out .
 ENTRYPOINT ["dotnet", "UmlautAdaptarr.dll"]


### PR DESCRIPTION
To get changelogs shown with Renovate a docker container has to add the source label described in the OCI Image Format Specification.

For reference: https://github.com/renovatebot/renovate/blob/main/lib/modules/datasource/docker/readme.md